### PR TITLE
Improve mobile layout and canvas sizing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2,13 +2,18 @@
     box-sizing: border-box;
 }
 
+:root {
+    --page-padding: 0.5rem;
+    --container-padding: 1.5rem;
+}
+
 body {
     display: flex;
     justify-content: center;
     align-items: center;
     min-height: 100vh;
     margin: 0;
-    padding: 0.5rem;
+    padding: var(--page-padding);
     background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     color: white;
@@ -22,43 +27,40 @@ body {
 .game-container {
     text-align: center;
     background: rgba(255, 255, 255, 0.08);
-    padding: 1.5rem;
+    padding: var(--container-padding);
     border-radius: 20px;
     backdrop-filter: blur(20px);
-    box-shadow: 
+    box-shadow:
         0 25px 50px -12px rgba(0, 0, 0, 0.25),
         0 0 0 1px rgba(255, 255, 255, 0.1);
     border: 1px solid rgba(255, 255, 255, 0.1);
     width: 100%;
-    max-width: min(90vw, 500px);
+    max-width: min(92vw, 520px);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: clamp(1rem, 3vw, 1.5rem);
     transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 /* Нормальный режим - вертикальная ориентация */
-.game-left, .game-right {
-    display: block;
+.game-left,
+.game-right {
+    width: 100%;
 }
 
 .game-left {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
     text-align: center;
+    gap: clamp(0.8rem, 3vw, 1.2rem);
 }
 
 .game-right {
+    display: flex;
+    justify-content: center;
     text-align: center;
-}
-
-/* Сброс мобильных стилей для десктопа */
-.game-container {
-    display: block;
-}
-
-.game-left {
-    flex: none;
-    display: block;
-}
-
-.game-right {
-    flex: none;
     margin-top: 0;
 }
 
@@ -102,13 +104,13 @@ h1 {
 #gameCanvas {
     border: 2px solid rgba(255, 255, 255, 0.2);
     border-radius: 16px;
-    box-shadow: 
+    box-shadow:
         0 20px 40px rgba(0,0,0,0.2),
         inset 0 1px 0 rgba(255, 255, 255, 0.1);
     background: rgba(0, 0, 0, 0.1);
     transition: all 0.3s ease;
-    width: min(400px, calc(100vw - 3rem));
-    height: min(400px, calc(100vw - 3rem));
+    width: min(400px, 90vmin, calc(100vw - (2 * var(--page-padding)) - (2 * var(--container-padding))));
+    height: min(400px, 90vmin, calc(100vw - (2 * var(--page-padding)) - (2 * var(--container-padding))));
     max-width: 400px;
     max-height: 400px;
     touch-action: none;
@@ -134,7 +136,7 @@ h1 {
     border-radius: 12px;
     border: 1px solid rgba(255, 255, 255, 0.05);
     width: 100%;
-    max-width: 400px;
+    max-width: min(400px, calc(100vw - (2 * var(--page-padding)) - (2 * var(--container-padding))));
     margin-left: auto;
     margin-right: auto;
 }
@@ -258,6 +260,10 @@ h1 {
     gap: clamp(0.5rem, 3vw, 1rem);
     margin-bottom: 1rem;
     flex-wrap: wrap;
+    width: 100%;
+    max-width: min(400px, calc(100vw - (2 * var(--page-padding)) - (2 * var(--container-padding))));
+    margin-left: auto;
+    margin-right: auto;
 }
 
 .stat-item {
@@ -305,28 +311,28 @@ h1 {
 
 /* Мобильные устройства */
 @media (max-width: 768px) {
-    body {
-        padding: 0.5rem;
+    :root {
+        --page-padding: clamp(0.35rem, 2.5vw, 0.55rem);
+        --container-padding: clamp(0.55rem, 4vw, 0.75rem);
     }
-    
+
     .game-container {
-        padding: 1rem;
         max-width: none;
-        width: calc(100vw - 1rem);
+        width: calc(100vw - (2 * var(--page-padding)));
         border-radius: 16px;
+        gap: clamp(0.85rem, 3vw, 1.2rem);
     }
-    
-    #gameCanvas {
-        width: min(320px, calc(100vw - 3rem));
-        height: min(320px, calc(100vw - 3rem));
+
+    .game-right {
+        justify-content: center;
     }
-    
+
     .game-over {
         max-width: 85vw;
         padding: 1.2rem;
         border-radius: 16px;
     }
-    
+
     .restart-btn {
         padding: 0.8rem 1.5rem;
         font-size: 1rem;
@@ -335,73 +341,80 @@ h1 {
 
 /* Маленькие телефоны */
 @media (max-width: 480px) {
-    body {
-        padding: 0.3rem;
+    :root {
+        --page-padding: clamp(0.3rem, 2.5vw, 0.45rem);
+        --container-padding: clamp(0.4rem, 4vw, 0.55rem);
     }
-    
+
     .game-container {
-        padding: 0.8rem;
-        width: calc(100vw - 0.6rem);
-        border-radius: 12px;
+        border-radius: 14px;
+        gap: clamp(0.75rem, 3.5vw, 1rem);
     }
-    
-    #gameCanvas {
-        width: min(280px, calc(100vw - 2rem));
-        height: min(280px, calc(100vw - 2rem));
+
+    .controls {
+        padding: clamp(0.7rem, 3.5vw, 0.95rem);
     }
-    
+
     .game-over {
         max-width: 90vw;
         padding: 1rem;
         border-radius: 12px;
     }
-    
+
     .game-over h2 {
         font-size: clamp(1.3rem, 4vw, 1.5rem);
     }
-    
+
     .restart-btn {
         padding: 0.7rem 1.2rem;
-        font-size: 0.9rem;
+        font-size: 0.95rem;
+    }
+}
+
+@media (max-width: 360px) {
+    :root {
+        --page-padding: clamp(0.25rem, 3vw, 0.35rem);
+        --container-padding: clamp(0.32rem, 4vw, 0.45rem);
+    }
+
+    .controls {
+        font-size: clamp(0.72rem, 3.2vw, 0.85rem);
     }
 }
 
 /* Ландшафтная ориентация на мобильных */
 @media (max-width: 768px) and (max-height: 500px) and (orientation: landscape) {
-    body {
-        padding: 0.2rem;
+    :root {
+        --page-padding: clamp(0.2rem, 2vw, 0.35rem);
+        --container-padding: clamp(0.35rem, 3vw, 0.5rem);
     }
-    
+
     .game-container {
-        padding: 0.5rem;
-        width: calc(100vw - 0.4rem);
-        height: calc(100vh - 0.4rem);
-        display: flex;
+        width: calc(100vw - (2 * var(--page-padding)));
+        height: calc(100vh - (2 * var(--page-padding)));
         flex-direction: row;
         align-items: center;
-        gap: 1rem;
-        border-radius: 8px;
+        gap: clamp(0.6rem, 2vw, 1rem);
+        border-radius: 10px;
     }
-    
+
     .game-left {
         flex: 1;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
         justify-content: center;
     }
-    
+
     .game-right {
         flex: 0 0 auto;
-        max-width: 200px;
+        max-width: min(45vw, 220px);
     }
-    
+
     #gameCanvas {
-        max-width: min(50vh, 300px);
+        width: min(300px, 50vh, calc(100vw - (2 * var(--page-padding)) - (2 * var(--container-padding))));
+        height: min(300px, 50vh, calc(100vw - (2 * var(--page-padding)) - (2 * var(--container-padding))));
     }
-    
+
     .controls {
-        font-size: 0.7rem;
+        font-size: clamp(0.68rem, 2vw, 0.8rem);
         padding: 0.5rem 0.7rem;
         line-height: 1.3;
     }


### PR DESCRIPTION
## Summary
- increase the mobile canvas footprint while keeping the gameplay area proportional
- switch to CSS custom properties so container and page padding scale by breakpoint
- refine responsive layout spacing for stats, controls, and landscape mode

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cc99a47d18832694440c554bbf8c9b