### PR TITLE
Fix structure launcher preview stats

### DIFF
--- a/structure_launcher.html
+++ b/structure_launcher.html
@@ -349,6 +349,9 @@
             
             // Обновляем информацию
             const scoreForLevel = (level - 1) * 50;
+            const nextLevelScore = level < 5 ? level * 50 : null;
+            const pointsToNext = level < 5 ? nextLevelScore - scoreForLevel : null;
+
             infoContainer.innerHTML = `
                 <strong>Длина змеи:</strong> ${snakeLength} сегментов<br>
                 <strong>Очки для уровня:</strong> ${scoreForLevel}<br>


### PR DESCRIPTION
## Summary
- calculate next-level score information in the structure launcher preview so the template uses defined values

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ccaa4a1dc08326affaf1747024f772