### PR TITLE
Merge mobile swipe improvements without conflicts

### DIFF
--- a/gameLogic.js
+++ b/gameLogic.js
@@ -408,6 +408,8 @@ function showWinScreen() {
         <h2 style="color: #f39c12;">🎉 Победа! 🎉</h2>
         <p>Поздравляем! Ты прошел все уровни!</p>
         <button class="restart-btn" onclick="restartGame()">Играть снова</button>
+        <p class="desktop-controls overlay-hint">Нажмите <strong>R</strong>, <strong>Enter</strong> или <strong>К</strong>, чтобы начать заново</p>
+        <p class="mobile-controls overlay-hint">Нажмите кнопку выше, чтобы сыграть ещё</p>
     `;
     
     document.body.appendChild(winScreen);
@@ -438,9 +440,10 @@ function restartGame() {
     immaterialTurns = 0;
     isNewStructureImmaterial = false;
     lastSnakeHead = null;
-    
+
     gameRunning = true;
-    
+    resetTouchTracking();
+
     initializeObstacles();
     
     // Если в режиме конкретной структуры, инициализируем змею с нужной длиной
@@ -460,7 +463,32 @@ let touchStartX = 0;
 let touchStartY = 0;
 let touchEndX = 0;
 let touchEndY = 0;
+let lastSwipeX = 0;
+let lastSwipeY = 0;
+let activeTouchId = null;
+let hasDirectionalSwipe = false;
 const minSwipeDistance = 40;
+const continuousSwipeDistance = 26;
+
+function resetTouchTracking() {
+    activeTouchId = null;
+    hasDirectionalSwipe = false;
+    touchStartX = 0;
+    touchStartY = 0;
+    touchEndX = 0;
+    touchEndY = 0;
+    lastSwipeX = 0;
+    lastSwipeY = 0;
+}
+
+function findTouchById(touchList, identifier) {
+    for (let i = 0; i < touchList.length; i++) {
+        if (touchList[i].identifier === identifier) {
+            return touchList[i];
+        }
+    }
+    return null;
+}
 
 // Функция для добавления направления в очередь
 function addDirectionToQueue(newDirection) {
@@ -470,6 +498,10 @@ function addDirectionToQueue(newDirection) {
         const lastCommand = inputQueue[inputQueue.length - 1];
         currentDx = lastCommand.dx;
         currentDy = lastCommand.dy;
+    }
+
+    if (newDirection.dx === currentDx && newDirection.dy === currentDy) {
+        return;
     }
 
     if ((dx === 0 && dy === 0) || !(newDirection.dx === -currentDx && newDirection.dy === -currentDy)) {
@@ -514,60 +546,124 @@ document.addEventListener('keydown', (e) => {
     }
 });
 
-// Обработка свайпов для мобильных устройств
-document.addEventListener('touchstart', (e) => {
-    const touch = e.touches[0];
+function shouldIgnoreTouchStart(target) {
+    if (!gameRunning) {
+        return true;
+    }
+
+    if (!target) {
+        return false;
+    }
+
+    if (target.closest('.restart-btn')) {
+        return true;
+    }
+
+    if (target.closest('.game-over')) {
+        return true;
+    }
+
+    return false;
+}
+
+function handleTouchStart(e) {
+    if (activeTouchId !== null) return;
+
+    const touch = e.changedTouches[0];
+    if (!touch) return;
+
+    if (shouldIgnoreTouchStart(e.target)) {
+        return;
+    }
+
+    activeTouchId = touch.identifier;
     touchStartX = touch.clientX;
     touchStartY = touch.clientY;
-}, { passive: true });
+    lastSwipeX = touch.clientX;
+    lastSwipeY = touch.clientY;
+    hasDirectionalSwipe = false;
+}
 
-document.addEventListener('touchend', (e) => {
-    const touch = e.changedTouches[0];
-    touchEndX = touch.clientX;
-    touchEndY = touch.clientY;
-    
-    if (!gameRunning) return;
-    
-    const deltaX = touchEndX - touchStartX;
-    const deltaY = touchEndY - touchStartY;
-    
-    // Проверяем, что это свайп, а не случайное касание
-    if (Math.abs(deltaX) > minSwipeDistance || Math.abs(deltaY) > minSwipeDistance) {
-        // ВСЕГДА предотвращаем скролл для любых свайпов
-        e.preventDefault();
-        
-        // Определяем направление свайпа
-        if (Math.abs(deltaX) > Math.abs(deltaY)) {
-            // Горизонтальный свайп
-            if (deltaX > minSwipeDistance) {
-                // Свайп вправо
-                addDirectionToQueue({dx: 1, dy: 0});
-            } else if (deltaX < -minSwipeDistance) {
-                // Свайп влево
-                addDirectionToQueue({dx: -1, dy: 0});
-            }
-        } else {
-            // Вертикальный свайп
-            if (deltaY > minSwipeDistance) {
-                // Свайп вниз
-                addDirectionToQueue({dx: 0, dy: 1});
-            } else if (deltaY < -minSwipeDistance) {
-                // Свайп вверх
-                addDirectionToQueue({dx: 0, dy: -1});
-            }
+function applySwipeFromDelta(deltaX, deltaY, threshold) {
+    if (Math.abs(deltaX) < threshold && Math.abs(deltaY) < threshold) {
+        return false;
+    }
+
+    if (Math.abs(deltaX) > Math.abs(deltaY)) {
+        if (deltaX >= threshold) {
+            addDirectionToQueue({dx: 1, dy: 0});
+            return true;
+        }
+
+        if (deltaX <= -threshold) {
+            addDirectionToQueue({dx: -1, dy: 0});
+            return true;
+        }
+    } else {
+        if (deltaY >= threshold) {
+            addDirectionToQueue({dx: 0, dy: 1});
+            return true;
+        }
+
+        if (deltaY <= -threshold) {
+            addDirectionToQueue({dx: 0, dy: -1});
+            return true;
         }
     }
-}, { passive: false });
 
-// Предотвращаем скролл страницы при любых касаниях
-document.addEventListener('touchmove', (e) => {
-    e.preventDefault();
-}, { passive: false });
+    return false;
+}
 
-// Предотвращаем зум и скролл при касании canvas
-canvas.addEventListener('touchmove', (e) => {
+function handleTouchMove(e) {
     e.preventDefault();
-}, { passive: false });
+
+    if (activeTouchId === null) {
+        return;
+    }
+
+    const touch = findTouchById(e.changedTouches, activeTouchId);
+    if (!touch) return;
+
+    if (!gameRunning) {
+        return;
+    }
+
+    const deltaX = touch.clientX - lastSwipeX;
+    const deltaY = touch.clientY - lastSwipeY;
+    const threshold = hasDirectionalSwipe ? continuousSwipeDistance : minSwipeDistance;
+
+    if (applySwipeFromDelta(deltaX, deltaY, threshold)) {
+        hasDirectionalSwipe = true;
+        lastSwipeX = touch.clientX;
+        lastSwipeY = touch.clientY;
+    }
+}
+
+function handleTouchEnd(e) {
+    if (activeTouchId === null) return;
+
+    const touch = findTouchById(e.changedTouches, activeTouchId);
+    if (!touch) return;
+
+    touchEndX = touch.clientX;
+    touchEndY = touch.clientY;
+
+    if (gameRunning && !hasDirectionalSwipe) {
+        const deltaX = touchEndX - touchStartX;
+        const deltaY = touchEndY - touchStartY;
+
+        if (applySwipeFromDelta(deltaX, deltaY, minSwipeDistance)) {
+            e.preventDefault();
+        }
+    }
+
+    resetTouchTracking();
+}
+
+document.addEventListener('touchstart', handleTouchStart, { passive: true });
+document.addEventListener('touchmove', handleTouchMove, { passive: false });
+document.addEventListener('touchend', handleTouchEnd, { passive: false });
+document.addEventListener('touchcancel', handleTouchEnd, { passive: false });
 
 // Обработка кнопок перезапуска для мобильных устройств
 document.addEventListener('touchstart', (e) => {

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
             <div class="controls">
                 <strong>Управление:</strong><br>
                 <span class="desktop-controls">Стрелки или WASD<br></span>
-                <span class="mobile-controls">Свайпы по игровому полю<br></span>
+                <span class="mobile-controls">Ведите пальцем по экрану без отрыва — повороты ловятся в движении<br></span>
                 🏆 Цель: 250 очков и все пять уровней<br>
                 🔄 Новые препятствия каждые 50 очков<br>
                 <span class="desktop-controls"><strong>R</strong>, <strong>Enter</strong> - перезапуск после Game Over</span>
@@ -44,8 +44,11 @@
             <h2>Игра окончена!</h2>
             <p>Ваш счёт: <span id="finalScore" class="score-value">0</span></p>
             <button class="restart-btn" onclick="restartGame()">Начать заново</button>
-            <p style="margin-top: 1rem; font-size: 0.9rem; opacity: 0.8;">
+            <p class="desktop-controls overlay-hint">
                 Или нажмите <strong>R</strong>, <strong>Enter</strong> или <strong>К</strong> для перезапуска
+            </p>
+            <p class="mobile-controls overlay-hint">
+                Или просто нажмите кнопку выше
             </p>
         </div>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -160,9 +160,33 @@ h1 {
     .desktop-controls {
         display: none;
     }
-    
+
     .mobile-controls {
         display: inline;
+    }
+}
+
+.overlay-hint {
+    margin-top: 1.25rem;
+    font-size: clamp(0.8rem, 2.8vw, 1rem);
+    opacity: 0.85;
+}
+
+.game-over .desktop-controls {
+    display: block;
+}
+
+.game-over .mobile-controls {
+    display: none;
+}
+
+@media (max-width: 768px) {
+    .game-over .desktop-controls {
+        display: none;
+    }
+
+    .game-over .mobile-controls {
+        display: block;
     }
 }
 


### PR DESCRIPTION
## Summary
- guard swipe activation against overlay targets while keeping document-wide listeners so drags anywhere on the page steer the snake without lifting a finger
- reuse a shared swipe-delta helper for move and release events to keep continuous direction changes responsive
- refresh the mobile control hint to highlight live turns during a full-screen drag

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cca343943c8326aa9b596edf4c5b61